### PR TITLE
fixed favorites fetch route and fix google oauth 2.0 

### DIFF
--- a/src/components/Favourites.jsx
+++ b/src/components/Favourites.jsx
@@ -13,7 +13,7 @@ const Favourites = ({onClose}) => {
 
   const fetchFavourites = async () => {
     try {
-      const data = await axiosPrivate.get("/spoonacular/recipes/favourite");
+      const data = await axiosPrivate.get("/recipes/favourite");
       const fetchedFavourites = data.data;
   
       setFavourites((prevFavourites) => {

--- a/src/utils/getGoogleUrl.js
+++ b/src/utils/getGoogleUrl.js
@@ -6,7 +6,6 @@ function getGoogleOAuthURL() {
       client_id: process.env.REACT_APP_CLIENT_ID_GOOGLE,
       access_type: "offline",
       response_type: "code",
-      prompt: "consent",
       scope: [
         "https://www.googleapis.com/auth/userinfo.profile",
         "https://www.googleapis.com/auth/userinfo.email",


### PR DESCRIPTION
I'm erase prompt in options for google oauth 2.0 
and fixed end-point to favorites recipes